### PR TITLE
Make sure roles are runnable in clean environment

### DIFF
--- a/.github/workflows/actions/run-playbook/action.yml
+++ b/.github/workflows/actions/run-playbook/action.yml
@@ -1,0 +1,16 @@
+name: "Run playbook"
+
+inputs:
+  tags:
+    required: true
+
+runs:
+  using: "composite"
+
+  steps:
+    - run: |
+        ansible-playbook playbook-github-ci.yml \
+        --vault-password-file vault.ci.sh \
+        --tags ${{ inputs.tags }} \
+        -v
+      shell: "bash"

--- a/.github/workflows/actions/setup/action.yml
+++ b/.github/workflows/actions/setup/action.yml
@@ -1,0 +1,29 @@
+name: "Setup"
+description: "Installs dependencies and sets up the environment"
+
+inputs:
+  ssh-keys:
+    description: "SSH keys for private repositories https://docs.github.com/en/authentication/connecting-to-github-with-ssh/managing-deploy-keys#deploy-keys"
+    required: true
+
+runs:
+  using: "composite"
+
+  steps:
+    - name: "Install deploy keys for private dependencies"
+      uses: "webfactory/ssh-agent@v0.9.0"
+      with:
+        ssh-private-key: "${{ inputs.ssh-keys }}"
+
+    - name: "Print Ansible environment"
+      run: "ansible --version"
+      shell: "bash"
+
+    - name: "Install from requirements.yml"
+      run: |
+        # Make passlib available in python environment
+        # https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#how-do-i-generate-encrypted-passwords-for-the-user-module
+        /opt/pipx/venvs/ansible-core/bin/python -m pip install passlib
+
+        ansible-galaxy install -r requirements.yml
+      shell: "bash"

--- a/.github/workflows/test-ansible-roles.yml
+++ b/.github/workflows/test-ansible-roles.yml
@@ -1,0 +1,151 @@
+name: "Test Ansible roles"
+
+on:
+  pull_request:
+    branches:
+      - "master"
+
+  push:
+    branches:
+      - "master"
+
+  workflow_dispatch:
+
+env:
+  SYSTEM_USER: "runner_42" # should match ansible_user (host_vars/github_ci/vars.yml)
+  SLEEP_BEFORE_LOADING_APP_URL_SECONDS: 120
+  SLEEP_BEFORE_SCREENSHOT_SECONDS: 10
+
+jobs:
+  system:
+    runs-on: "ubuntu-22.04"
+
+    steps:
+      - uses: "actions/checkout@v4"
+
+      - uses: "./.github/workflows/actions/setup"
+        with:
+          ssh-keys: |
+            ${{ secrets.GH_DEPLOYKEY_ANSIBLE_COLLECTION_SELFHOSTED }}
+            ${{ secrets.GH_DEPLOYKEY_ANSIBLE_COLLECTION_SMARTHOME }}
+            ${{ secrets.GH_DEPLOYKEY_ANSIBLE_COLLECTION_YAMS }}
+
+      - uses: "./.github/workflows/actions/run-playbook"
+        with:
+          tags: "system,zsh"
+
+      - name: "Test if ${{ env.SYSTEM_USER }} user exists"
+        run: "sudo passwd --status ${{ env.SYSTEM_USER }}"
+
+  docker:
+    runs-on: "ubuntu-22.04"
+
+    strategy:
+      matrix:
+        role:
+          - name: "immich"
+            tags: "system,docker,media"
+            screenshot_url: "http://localhost:3001"
+
+          - name: "jellyfin"
+            tags: "system,docker,media"
+            screenshot_url: "http://localhost:3002"
+
+          - name: "jellyseerr"
+            tags: "system,docker,media"
+            screenshot_url: "http://localhost:3003"
+
+          - name: "paperlessngx"
+            tags: "system,docker,media"
+            screenshot_url: "http://localhost:3004"
+
+          - name: "prowlarr"
+            tags: "system,docker,media"
+            screenshot_url: "http://localhost:3005"
+
+          - name: "radarr"
+            tags: "system,docker,media"
+            screenshot_url: "http://localhost:3006"
+
+          - name: "sonarr"
+            tags: "system,docker,media"
+            screenshot_url: "http://localhost:3007"
+
+          - name: "transmission"
+            tags: "system,docker,media"
+            screenshot_url: "http://runner_42:test4242@localhost:3008"
+
+          - name: "duplicati"
+            tags: "system,docker,duplicati"
+            screenshot_url: "http://localhost:3009"
+
+          - name: "filebrowser"
+            tags: "system,docker,storage"
+            screenshot_url: "http://localhost:3010"
+
+          - name: "glances"
+            tags: "system,docker,monitoring"
+            screenshot_url: "http://localhost:61208"
+
+          - name: "homebox"
+            tags: "system,docker,homebox"
+            screenshot_url: "http://localhost:3011"
+
+          - name: "miniflux"
+            tags: "system,docker,rss"
+            screenshot_url: "http://localhost:3012"
+
+          - name: "rssbridge"
+            tags: "system,docker,rss"
+            screenshot_url: "http://localhost:3013"
+
+          - name: "vaultwarden"
+            tags: "system,docker,vaultwarden"
+            screenshot_url: "http://localhost:3014"
+
+          - name: "wallos"
+            tags: "system,docker,wallos"
+            screenshot_url: "http://localhost:3015"
+
+          - name: "wg-easy"
+            tags: "system,docker,wireguard"
+            screenshot_url: "http://localhost:3016"
+
+          - name: "homeassistant"
+            tags: "system,docker,smarthome"
+            screenshot_url: "http://localhost:3017"
+
+    steps:
+      - uses: "actions/checkout@v4"
+
+      - uses: "./.github/workflows/actions/setup"
+        with:
+          ssh-keys: |
+            ${{ secrets.GH_DEPLOYKEY_ANSIBLE_COLLECTION_SELFHOSTED }}
+            ${{ secrets.GH_DEPLOYKEY_ANSIBLE_COLLECTION_SMARTHOME }}
+            ${{ secrets.GH_DEPLOYKEY_ANSIBLE_COLLECTION_YAMS }}
+
+      - uses: "./.github/workflows/actions/run-playbook"
+        with:
+          tags: "${{ matrix.role.tags }}"
+
+      - name: "Sleep before loading app"
+        run: "sleep ${{ env.SLEEP_BEFORE_LOADING_APP_URL_SECONDS }}"
+
+      - name: "Print docker processes"
+        run: "docker ps -a"
+
+      - name: "Make a screenshot of ${{ matrix.role.screenshot_url }}"
+        uses: "karol-brejna-i/webpage-screenshot-action@v1"
+        with:
+          url: "${{ matrix.role.screenshot_url }}"
+          scriptBefore: |
+            var waitTill = new Date(new Date().getTime() + ${{ env.SLEEP_BEFORE_SCREENSHOT_SECONDS }} * 1000);
+            while(waitTill > new Date()){}
+          output: "screenshot-${{ matrix.role.name }}.png"
+
+      - name: "Upload screenshots"
+        uses: "actions/upload-artifact@v3"
+        with:
+          name: "screenshots"
+          path: "${{ github.workspace }}/screenshot-*.png"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # artyorsh/homelab
 
+![Tests](https://github.com/artyorsh/infra/actions/workflows/test-ansible-roles.yml/badge.svg?event=push)
+
 ## Usage (macOS)
 
 Install Ansible

--- a/host_vars/github_ci/vars.yml
+++ b/host_vars/github_ci/vars.yml
@@ -1,0 +1,92 @@
+---
+ansible_user: "runner_42"
+
+system_user_name: "{{ ansible_user }}"
+system_user_password: "test4242"
+system_timezone: "Europe/Amsterdam"
+
+system_user_uid: "4242"
+system_user_gid: "4242"
+
+docker_bridge_network_settings:
+  network: "docker-network-main"
+  puid: "{{ system_user_uid }}"
+  pgid: "{{ system_user_gid }}"
+  tz: "{{ system_timezone }}"
+
+docker_host_network_settings:
+  network: "host"
+  puid: "host"
+  pgid: "{{ system_user_gid }}"
+  tz: "{{ system_timezone }}"
+
+# TODO: with this variable being "false", Watchtower installation is ignored, making it not testable
+# The underlying role needs to be splitted
+docker_autoupdate_enabled: false
+
+#################################
+# ansilbe-collection-yams       #
+#################################
+
+yams_docker_settings: "{{ docker_bridge_network_settings }}"
+yams_user:
+  name: "{{ system_user_name }}"
+  password: "{{ system_user_password }}"
+
+immich_port: 3001
+
+jellyfin_port: 3002
+jellyfin_jellyseerr_port: 3003
+
+paperlessngx_port: 3004
+
+prowlarr_port: 3005
+
+radarr_port: 3006
+
+sonarr_port: 3007
+
+transmission_ui_port: 3008
+transmission_whitelist:
+  - "*.*.*.*"
+
+#################################
+# ansilbe-collection-selfhosted #
+#################################
+
+duplicati_docker_settings: "{{ docker_bridge_network_settings }}"
+duplicati_port: 3009
+
+filebrowser_docker_settings: "{{ docker_bridge_network_settings }}"
+storage_filebrowser_port: 3010
+
+glances_docker_settings: "{{ docker_host_network_settings }}"
+glances_webui_port: 61208
+
+homebox_docker_settings: "{{ docker_bridge_network_settings }}"
+homebox_webui_port: 3011
+
+rss_docker_settings: "{{ docker_bridge_network_settings }}"
+rss_miniflux_webui_port: 3012
+rss_rssbridge_webui_port: 3013
+
+vaultwarden_docker_settings: "{{ docker_bridge_network_settings }}"
+vaultwarden_port: 3014
+
+wallos_docker_settings: "{{ docker_bridge_network_settings }}"
+wallos_webui_port: 3015
+
+wgeasy_docker_settings: "{{ docker_bridge_network_settings }}"
+wireguard_mode: "server"
+wgeasy_webui_port: 3016
+
+#################################
+# ansilbe-collection-smarthome  #
+#################################
+
+smarthome_docker_settings: "{{ docker_bridge_network_settings }}"
+
+# TODO: with this variable being empty, zigbee2mqtt installation is ignored, making it not testable
+smarthome_zigbee_coordinator: ""
+
+homeassistant_port: 3017

--- a/host_vars/pi/vars.yml
+++ b/host_vars/pi/vars.yml
@@ -1,4 +1,6 @@
 ---
+smarthome_zigbee_coordinator: "/dev/ttyUSB0"
+
 docker_bridge_network_settings:
   network: "docker-network-main"
   puid: "{{ system_user_uid }}"

--- a/host_vars/pi/vars.yml
+++ b/host_vars/pi/vars.yml
@@ -13,6 +13,8 @@ docker_host_network_settings:
   pgid: "{{ system_user_gid }}"
   tz: "{{ system_timezone }}"
 
+docker_autoupdate_enabled: true
+
 docker_autobackup_containers:
   - name: "adguardhome"
     volumes:

--- a/host_vars/vps/vars.yml
+++ b/host_vars/vps/vars.yml
@@ -10,3 +10,5 @@ docker_host_network_settings:
   puid: "host"
   pgid: "{{ system_user_gid }}"
   tz: "{{ system_timezone }}"
+
+docker_autoupdate_enabled: true

--- a/inventory.yml
+++ b/inventory.yml
@@ -1,6 +1,10 @@
 ---
 all:
   hosts:
+    github_ci:
+      ansible_host: "127.0.0.1"
+      ansible_connection: "local"
+
     mac:
       ansible_host: "127.0.0.1"
       ansible_connection: "local"

--- a/playbook-github-ci.yml
+++ b/playbook-github-ci.yml
@@ -1,0 +1,57 @@
+---
+- name: "Provision github_ci host"
+  hosts: "github_ci"
+  become: true
+
+  roles:
+    - role: "system"
+      tags:
+        - "system"
+
+    - role: "zsh"
+      tags:
+        - "zsh"
+
+    - role: "docker"
+      tags:
+        - "docker"
+
+    - role: "storage"
+      tags:
+        - "storage"
+
+    - role: "monitoring"
+      tags:
+        - "monitoring"
+
+    - role: "artyorsh.yams.yams"
+      tags:
+        - "media"
+
+    - role: "artyorsh.smarthome.smarthome"
+      tags:
+        - "smarthome"
+
+    - role: "artyorsh.selfhosted.rss"
+      tags:
+        - "rss"
+
+    - role: "artyorsh.selfhosted.homebox"
+      tags:
+        - "homebox"
+
+    - role: "artyorsh.selfhosted.vaultwarden"
+      tags:
+        - "vaultwarden"
+
+    - role: "artyorsh.selfhosted.duplicati"
+      tags:
+        - "duplicati"
+
+    - role: "artyorsh.selfhosted.wallos"
+      tags:
+        - "wallos"
+
+    - role: "wireguard"
+      tags:
+        - "wireguard"

--- a/playbook-pi.yml
+++ b/playbook-pi.yml
@@ -59,7 +59,7 @@
 
     - role: "artyorsh.smarthome.smarthome"
       vars:
-        smarthome_zigbee_coordinator: "/dev/ttyUSB0"
+        # smarthome_zigbee_coordinator: "/dev/ttyUSB0"
 
         smarthome_user:
           name: "{{ system_user_name }}"

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -12,7 +12,7 @@
     docker_autoprune_schedule: { weekday: "*", hour: 1, minute: 30 }
     docker_autoprune_until_hours: 168
 
-    docker_autoupdate_enabled: true
+    # docker_autoupdate_enabled: true
     docker_autoupdate_ignore_list:
       - "cloudflare"
       - "wireguard"

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -1,8 +1,4 @@
 ---
-- name: "Create shared network"
-  community.general.docker_network:
-    name: "{{ docker_network_name }}"
-
 - name: "Install and configure Docker"
   ansible.builtin.include_role:
     name: "artyorsh.selfhosted.docker"

--- a/roles/monitoring/tasks/main.yml
+++ b/roles/monitoring/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: "Template notification script"
   ansible.builtin.template:
     src: "notify.sh.j2"
-    dest: "/opt/docker/glances/notify.sh"
+    dest: "/etc/glances-notify.sh"
     owner: "{{ system_user_name }}"
     group: "{{ system_user_group }}"
     mode: "0740"
@@ -11,7 +11,7 @@
   ansible.builtin.include_role:
     name: "artyorsh.selfhosted.glances"
   vars:
-    glances_notifier: "/opt/docker/glances/notify.sh"
+    glances_notifier: "/etc/glances-notify.sh"
     glances_fs_volumes:
       - "{{ storage_smb_share_local_dir }}"
     glances_docker_settings: "{{ docker_host_network_settings }}"

--- a/roles/monitoring/templates/notify.sh.j2
+++ b/roles/monitoring/templates/notify.sh.j2
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-curl -s -X POST https://api.telegram.org/bot{{ glances_telegram_bot_token }}/sendMessage \
--d chat_id={{ glances_telegram_bot_chatid }} \
+curl -s -X POST https://api.telegram.org/bot{{ glances_telegram_bot_token | default('') }}/sendMessage \
+-d chat_id={{ glances_telegram_bot_chatid | default('') }} \
 -d text="$1"

--- a/roles/security/tasks/iptables.yml
+++ b/roles/security/tasks/iptables.yml
@@ -1,4 +1,12 @@
 ---
+- name: "Make sure iptables packages are installed"
+  ansible.builtin.package:
+    name: "{{ item }}"
+    state: "present"
+  loop:
+    - "iptables"
+    - "iptables-persistent"
+
 - name: "Define ipv4 interface for Docker"
   block:
     - name: "Define ipv4 interface for Docker (wireguard host)"

--- a/roles/storage/defaults/main.yml
+++ b/roles/storage/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-storage_smb_share_address: "//192.168.0.1/path/to/shared"
+storage_smb_share_address: "" # e.g "//192.168.0.1/path/to/shared"
 storage_smb_share_user: "{{ system_user_name }}"
 storage_smb_share_password: "{{ system_user_password }}"
 storage_smb_share_local_dir: "/mnt/data"

--- a/roles/storage/tasks/main.yml
+++ b/roles/storage/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: "Connect SMB Share"
-  when: storage_smb_share_address is defined
+  when: storage_smb_share_address | length > 0
   ansible.builtin.include_tasks: "smb.yml"
 
 - name: "Install Filebrowser"

--- a/vault.ci.sh
+++ b/vault.ci.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "no-vault-required"


### PR DESCRIPTION
This introduces a separate playbook runnable by github to test Ansible roles end-to-end. Docker containers with web apps are tested by opening a `http://localhost:PORT` url and making a screenshot.

## Roles that [were tested](https://github.com/artyorsh/infra/actions/runs/9555151510) successfully

- [x] system
- [x] zsh
- [ ] security (fixes: 430ad6c). Unfortunately it [fails](https://github.com/artyorsh/infra/actions/runs/9503514895) on the last step attempting to start iptables.service
- [x] docker
- [ ] adguardhome (fixes: https://github.com/artyorsh/ansible-collection-selfhosted/commit/af78d79a46fbc3e349ab7813d97022903fe2e02a). [Yes](https://github.com/artyorsh/infra/actions/runs/9507468007), but needs checking if does not fails because of port 53 being used. 
- [x] wireguard (server mode)
- [x] storage (fixes: 0594873, https://github.com/artyorsh/ansible-collection-selfhosted/commit/e3b519efaf0de619213c7663b73760f7bd770dd6).
- [x] media (fixes: https://github.com/artyorsh/ansible-collection-yams/commit/95dc95177746c4b4bc9c8c0d3282ed82724e2506)
- [x] smarthome (fixes: 620c67f, https://github.com/artyorsh/ansible-collection-smarthome/commit/e3a19dd78517db40ca50dfe992c1f14372630a65, https://github.com/artyorsh/ansible-collection-smarthome/commit/fddfb3b369a8e7927ab0f33a242f2b97bf6d83c2). 
- [x] monitoring (fixes: 63ea870, https://github.com/artyorsh/ansible-collection-selfhosted/commit/aad2a4ac1fa9c3c533ff084907a1758af93dab30)
- [x] rss (fixes: https://github.com/artyorsh/ansible-collection-selfhosted/commit/6ee76b8b64fc19662bfc68a07c0e48ec6be6c70b)
- [x] duplicati (fixes: https://github.com/artyorsh/ansible-collection-selfhosted/commit/5139edf4883265304a1d7980083beb666d47e5af)
- [x] wallos (fixes: https://github.com/artyorsh/ansible-collection-selfhosted/commit/c8dc2f45ab9a351b2d5c817cc77e19e32109e648)
- [ ] cloudflare

## Not tested by action
- crontab modifications
- docker: Watchtower setup and backup/restore scripts
- wireguard: client mode
- storage:  share mounting
- smarthome: zigbee2mqtt container (a coordinator device needs to be plugged)

## General fixes in dependant collections:
- https://github.com/artyorsh/ansible-collection-selfhosted/commit/e50f4201de7035d796aa5eb7bf4b992eb82f6f84
- https://github.com/artyorsh/ansible-collection-yams/commit/a5633314222087daaf2a9b532b373d7d1cfec68c
- https://github.com/artyorsh/ansible-collection-yams/commit/c9fe9a43babf04fef5e4fa007a192cb66ea75aa6
- https://github.com/artyorsh/ansible-collection-smarthome/commit/b0370360855485954ca8b9b5d8cf03d427a43454